### PR TITLE
Upgrade semaphore workflows to use ubuntu2004

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Test
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - name: Test
     task:


### PR DESCRIPTION
Semaphore no longer supports using Ubuntu 18.04.

See https://www.notion.so/twostoryrobot/Semaphore-Ubuntu-18-04-EOL-c53e62851ecd4f2087ffab6c2c34d837.
